### PR TITLE
Add validation to for artist id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+# Comment out vim swap files
+*.swp

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -5,7 +5,11 @@ class Album < ActiveRecord::Base
 
   protected
   def artist_id_exists
-    return false if Artist.find_by_id(self.artist_id).nil?
+    if Artist.find_by_id(self.artist_id).nil? 
+      return false 
+    else
+      return true 
+    end
   end
 
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,12 @@
 class Album < ActiveRecord::Base
-	belongs_to :artist
+	belongs_to :artist 
 
-	validates :title, :artist_id, presence: true
+	validates :artist_id_exists, :title, :artist_id, presence: true
+
+  protected
+  def artist_id_exists
+    return false if Artist.find_by_id(self.artist_id).nil?
+  end
+
 end
+

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -8,6 +8,9 @@ class AlbumsControllerTest < ActionController::TestCase
 	end
 
   test "should get index" do 
+    # Saving artist id as 1
+    @artist.id=1
+    @artist.save
   	get :index
   	assert_response :success
   	assert_template :index
@@ -26,11 +29,12 @@ class AlbumsControllerTest < ActionController::TestCase
   end
 
   test "should get create" do 
+    @artist.id=1
+    @artist.save
   	assert_difference('Album.count', 1) do 
   		post :create, { album: @params }
   	end
-
-  	assert_response :redirect
+    assert_response :redirect
   end
 
   test "should get edit" do 
@@ -40,6 +44,8 @@ class AlbumsControllerTest < ActionController::TestCase
   end
 
   test "should get update" do 
+    @artist.id=1
+    @artist.save
   	put :update, id: @album, album: { title: 'Far' }
   	assert_response :redirect
   	assert_equal 'Far', Album.find(@album.id).title

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -3,10 +3,21 @@ require 'test_helper'
 class AlbumTest < ActiveSupport::TestCase
   def setup
   	@album = albums(:valid)
+    # Setup an artist fixture
+    @artist = artists(:valid)
   end
 
   test "@album is valid" do 
+    # Need to save artist before you can save album
+    # Since album saves a foreign key that references an artist row
+    @artist.id=1
+    @artist.save
+    # Is fixture actually saving artist to db?
   	assert @album.save
+  end
+
+  test "@album is invalid with an invalid foreign key" do
+    assert_not @album.save
   end
 
   test "responds to title" do 
@@ -22,8 +33,9 @@ class AlbumTest < ActiveSupport::TestCase
   	assert_not @album.save
   end
 
-  test "must have artist" do 
+  test "must have artist id" do 
   	@album.artist_id = ''
   	assert_not @album.save
   end
+
 end


### PR DESCRIPTION
Fixes issue #1.

Check if artist id has an existing artist. If it doesn't then the validation will fail. This prevents the album model saving an album with an invalid artist id. Previously, the album could be saved with an invalid artist id. However, when Album#index page was called it would throw an exception since there was no artist linked to the artist id.
- Add validation in Album model to check if artist id references a valid artist row.
- Make test suite pass by explicitly setting artist id to 1 in the necessary places. The active record fixture docs explain what happen when you don't explicitly set an id. See [Stable, Autogenerated IDs](http://api.rubyonrails.org/v3.2.8/classes/ActiveRecord/Fixtures.html)
- Add a new test to check that an album cannot be saved without a valid artist id.
- Reword testing the test for an empty artist id for readability.
