### PR TITLE
Correct appearance of artist names during album creation

### DIFF
--- a/app/views/albums/_form.html.haml
+++ b/app/views/albums/_form.html.haml
@@ -1,7 +1,7 @@
 = simple_form_for @album, :html => { :class => 'form-horizontal' } do |f|
   = f.input :title
   = error_span(@album[:title])
-  = f.input :artist_id
+  = f.input :artist_id, :collection => Artist.all
   = error_span(@album[:artist_id])
   = f.button :submit, :class => 'btn-primary'
   = link_to t('.cancel', :default => t("helpers.links.cancel")), albums_path, :class => 'btn btn-default'

--- a/app/views/albums/show.html.haml
+++ b/app/views/albums/show.html.haml
@@ -9,7 +9,7 @@
 %p
   %strong= model_class.human_attribute_name(:artist_id) + ':'
   %br
-  = @album.artist_id
+  = Artist.find(@album.artist_id).name
 
 
 = link_to t('.back', :default => t("helpers.links.back")), albums_path, :class => 'btn btn-default'


### PR DESCRIPTION
Previously, the Artist selection while creating a new album was generated as a numeric with no obvious relation to the Artists list. It will now display the artist's name both when you are creating a new album (in a select control) and immediately after creation on the show/info page.
